### PR TITLE
Implement DNS-SRV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+
+# IDEA specific
+.idea

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -19,6 +19,7 @@ akka {
 
         resolve-ipv4 = true
         resolve-ipv6 = true
+        resolve-srv  = false
 
         # How often to sweep out expired cache entries.
         # Note that this interval has nothing to do with TTLs

--- a/src/main/scala/ru/smslv/akka/dns/raw/RecordType.scala
+++ b/src/main/scala/ru/smslv/akka/dns/raw/RecordType.scala
@@ -20,6 +20,7 @@ object RecordType extends Enumeration {
   val MX = Value(15)
   val TXT = Value(16)
   val AAAA = Value(28)
+  val SRV = Value(33)
 
   val AXFR = Value(252)
   val MAILB = Value(253)


### PR DESCRIPTION
Implements DNS-SRV capabilities. By default this is disabled in order to comply entirely with the existing implementation.

When DNS-SRV is enabled via config, any `Resolve` request with a name starting with `_` will cause a new `SrvResolved` message to be in place of the existing `Dns.Resolved` message. Note that names beginning with `_` are a convention introduced by the [DNS SRV rfc](https://tools.ietf.org/html/rfc2782).

Upon receiving an `SrvResolved` It is then up to the client to decide what more should be done, keeping this library as simple as can be. The client's responsibilities should include determining which of the `SRVRecord` elements passed back should be further resolved via its `target` property, perhaps as per "Usage Rules" of the [DNS SRV rfc](https://tools.ietf.org/html/rfc2782).
